### PR TITLE
Include versions for imagej-launcher and imagej-matlab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-launcher</artifactId>
+			<version>${imagej-launcher.version}</version>
 		</dependency>
 
 		<!-- ImageJ Legacy - https://github.com/imagej/imagej-legacy -->
@@ -153,6 +154,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-matlab</artifactId>
+			<version>${imagej-matlab.version}</version>
 		</dependency>
 
 		<!-- ImageJ Mesh - https://github.com/imagej/imagej-mesh -->


### PR DESCRIPTION
For some reason I cannot explain, the maven build (on travis.org and local) was failing without these version declarations. Let's see if this fixes the travis build.